### PR TITLE
Improve GitHub Issue template to request a pull-request reference

### DIFF
--- a/.github/ISSUE_TEMPLATE/please-can-i-join-this-organisation------.md
+++ b/.github/ISSUE_TEMPLATE/please-can-i-join-this-organisation------.md
@@ -10,6 +10,14 @@ assignees: CodingSpecies
 
 ## Name: 
 
-## Info About the Pull Request You Made: 
+Your name here...
 
-> You can put the number of your pull request, but putting `#` with the number your pull request is at.
+## Why do you want to join this organization?
+
+Explain here...
+
+## Pull request with your contribution
+
+Replace this with a link to the pull-request with your contributions.
+
+If you have not created a pull-request yet, please follow [these instructions](https://github.com/App-Choreography/Get-An-Invite#readme) first.


### PR DESCRIPTION
Based on the most recent GitHub issues in this repository, it seems that people who want to join this organization are skipping the step that requires the creation of a pull-request with contributions. They are also mixing the template's content with their own, which results in confusing invitation requests.

I propose to modify the GitHub issue template to force future contributors to follow the step-by-step available in the README.md file, and to also replace the necessary text in the invitation request to answer the questions about why do they want to join the organization as well as a link to the pull-request.